### PR TITLE
Support unobfuscated jars

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,13 +121,18 @@ async function decompile (version, options = {}) {
 
   async function work () {
     const sideJarURL = versionManifest.downloads[side].url
-    const sideMappingsURL = versionManifest.downloads[side + '_mappings'].url
-    // Download and save the [client|server].jar and [client|server]_mappings.txt to the path folder
+    const sideMappingsURL = versionManifest.downloads[side + '_mappings']?.url
+    // Download and save the [client|server].jar and optionally, [client|server]_mappings.txt to the path folder
     if (!fs.existsSync(jarPath)) exec(`curl -L -o ${jarPath} ${sideJarURL}`)
-    if (!fs.existsSync(mappingsPath)) exec(`curl -L -o ${mappingsPath} ${sideMappingsURL}`)
-    // Now remap the [client|server].jar to [client|server]-remapped.jar
-    const remapped = await remap(fs.readFileSync(mappingsPath, 'utf-8'))
-
+    let remapped
+    if (sideMappingsURL) {
+      if (!fs.existsSync(mappingsPath)) exec(`curl -L -o ${mappingsPath} ${sideMappingsURL}`))
+      // Now remap the [client|server].jar to [client|server]-remapped.jar
+      remapped = await remap(fs.readFileSync(mappingsPath, 'utf-8'))
+    } else {
+      // Jar is already remaped
+      remapped = jarPath
+    }
     if (decompiler.type === 'fernflower') {
       return await decFernFlower(remapped, decompiler.options)
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ async function decompile (version, options = {}) {
     if (!fs.existsSync(jarPath)) exec(`curl -L -o ${jarPath} ${sideJarURL}`)
     let remapped
     if (sideMappingsURL) {
-      if (!fs.existsSync(mappingsPath)) exec(`curl -L -o ${mappingsPath} ${sideMappingsURL}`))
+      if (!fs.existsSync(mappingsPath)) exec(`curl -L -o ${mappingsPath} ${sideMappingsURL}`)
       // Now remap the [client|server].jar to [client|server]-remapped.jar
       remapped = await remap(fs.readFileSync(mappingsPath, 'utf-8'))
     } else {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -19,4 +19,3 @@ describe('decompile api works', () => {
     assert(fs.existsSync(srcDir))
   }).timeout(1000 * 60 * 10)
 })
-

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -13,9 +13,10 @@ describe('decompile api works', () => {
   }).timeout(1000 * 60 * 10)
 
   it('on server', async function () {
-    const version = '24w14a'
+    const version = '26.1-snapshot-5' // '24w14a'
     await lib.decompile(version, { side: 'server' })
     const srcDir = join(__dirname, '../versions/', version, '/server/version.json')
     assert(fs.existsSync(srcDir))
   }).timeout(1000 * 60 * 10)
 })
+


### PR DESCRIPTION
New Minecraft versions are no longer obfuscated and need no remapping step. 

Test new versioning schema with no more remap step